### PR TITLE
Evitar que el título del blog se quede

### DIFF
--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,11 +1,17 @@
 <script>
   import { updateMenuSelector } from '@/lib/menuSelectorUpdater.js';
+  import { onDestroy } from 'svelte';
   import ReadingTime from '@/components/ReadingTime.svelte';
   import HumanDate from '@/components/HumanDate.svelte';
   export let data
   const { post } = data
 
   updateMenuSelector({url: '/blog', color: 'text-cmxgreen'})
+  const title = document.title
+
+  onDestroy(() => {
+    document.title = title
+  })
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Cambios para corregir issue #53 :
- Se obtiene el titulo antes de montar el componente del articulo y se le pasa el valor al title al desmontarlo
- Los metatags no son necesario reeemplazarlos porque no se quedan en el head